### PR TITLE
refactor isBlocked & handleSocialMediaSignin and remove unecessary un…

### DIFF
--- a/manager/accounts.js
+++ b/manager/accounts.js
@@ -70,52 +70,53 @@ exports.updateAndGenerateCode = async (_id, type) => {
     }
 }
 
-exports.isBlocked = async (user, auth = false) => {
-    let dateNow = Math.floor(Date.now() / 1000)
-    var res = false
-    let logBlock = {}
-    if (auth) {
-        if (user.account_locked) {
-            if (
-                this.differenceBetweenDates(user.date_locked, dateNow) <
-                process.env.lockedPeriod
-            ) {
-                logBlock.date_locked = dateNow
-                logBlock.failed_count = 0
-                res = true
-            } else {
-                logBlock.failed_count = 0
-                logBlock.account_locked = false
-                res = false
-            }
+exports.isBlocked = async (user, isAuthAttempt = false) => {
+    const currentTime = Math.floor(Date.now() / 1000);
+    let [isBlocked,updateFields] = [false,{}];
+
+    if (isAuthAttempt) {
+        if (user.account_locked && this.differenceBetweenDates(user.date_locked, currentTime) < process.env.lockedPeriod) {
+            // If the user is locked and the locked period hasn't passed yet, reset the failed attempts and keep the account locked
+            updateFields.date_locked = currentTime;
+            updateFields.failed_count = 0;
+            isBlocked = true;
+        } else {
+            // If the locked period has passed, unlock the account
+            updateFields.failed_count = 0;
+            updateFields.account_locked = false;
+            isBlocked = false;
         }
     } else {
-        let failed_count = user.failed_count ? user.failed_count + 1 : 1
-        logBlock.failed_count = failed_count
-        if (failed_count == 1) logBlock.dateFirstAttempt = dateNow
+        let failedAttempts = user.failed_count ? user.failed_count + 1 : 1;
+        updateFields.failed_count = failedAttempts;
+
+        if (failedAttempts === 1) {
+            updateFields.dateFirstAttempt = currentTime;
+        }
+
         if (user.account_locked) {
-            logBlock.date_locked = dateNow
-            logBlock.failed_count = 0
-            res = true
-        } else if (
-            !user.account_locked &&
-            failed_count >= process.env.bad_login_limit &&
-            this.differenceBetweenDates(user.dateFirstAttempt, dateNow) <
-                process.env.failInterval
-        ) {
-            logBlock.account_locked = true
-            logBlock.failed_count = 0
-            logBlock.date_locked = dateNow
-            res = true
-        } else if (failed_count >= process.env.bad_login_limit)
-            logBlock.failed_count = 1
+            // If the user is already locked, reset the failed attempts and update the locked date
+            updateFields.date_locked = currentTime;
+            updateFields.failed_count = 0;
+            isBlocked = true;
+        } else if (!user.account_locked && failedAttempts >= process.env.bad_login_limit &&
+            this.differenceBetweenDates(user.dateFirstAttempt, currentTime) < process.env.failInterval) {
+            // If the user is not locked, and they've reached the limit of failed attempts in the given interval, lock the account
+            updateFields.account_locked = true;
+            updateFields.failed_count = 0;
+            updateFields.date_locked = currentTime;
+            isBlocked = true;
+        } else if (failedAttempts >= process.env.bad_login_limit) {
+            // If the user has reached the limit of failed attempts but not in the given interval, reset the failed attempts count
+            updateFields.failed_count = 1;
+        }
     }
-    if (Object.keys(logBlock).length)
-        await User.updateOne({ _id: user._id }, { $set: logBlock })
+        // If there are any changes, update the user record in the database
+        Object.keys(updateFields).length && await User.updateOne({ _id: user._id }, { $set: updateFields });
+    
 
-    return { res, blockedDate: dateNow, auth }
+    return { res: isBlocked, blockedDate: currentTime, auth: isAuthAttempt };
 }
-
 exports.getDecimal = (symbol) => {
     try {
         let token_info = Tokens

--- a/middleware/passport.middleware.js
+++ b/middleware/passport.middleware.js
@@ -652,42 +652,24 @@ exports.telegramConnection = (req, res) => {
  *end signin with telegram strategy
  */
 
+
 /*
  * begin connect account with facebook strategy
  */
-
-  exports.linkFacebookAccount = async (req, profile, cb) => {
-    const user_id = +req.query.state.split('|')[0];
-    const token_for_business = profile._json.token_for_business;
-    let response =   { status: false, message: 'account exist' };
-    if (!(await User.exists({ idOnSn: token_for_business }))) {
-      await User.updateOne({ _id: user_id }, { $set: { idOnSn: token_for_business, completed: true } });
-      response = { status: true, message: 'account_linked_with success' };
-    } 
-  
-    
-    return cb(null, profile, response);
-  }
-/*
- * end connect account with facebook strategy
- */
-
-/*
- * begin connect account with google strategy
- */
-
-exports.linkGoogleAccount = async (req, profile, done) => {
+ exports.linkSocialAccount = async ({ req, profile, done, token_field, id_field }) =>{
     let state = req.query.state.split('|');
     let user_id = +state[0];
     let response = { status: false, message: 'account exist' };
+    let id = id_field ? profile._json[id_field] : profile.id;
 
-    if (!(await User.exists({ idOnSn2: profile.id }))) {
-        await User.updateOne({ _id: user_id }, { $set: { idOnSn2: profile.id, completed: true } });
+    if (!(await User.exists({ [token_field]: id }))) {
+        await User.updateOne({ _id: user_id }, { $set: { [token_field]: id, completed: true } });
         response = { status: true, message: 'account_linked_with success' };
     }
 
     return done(null, profile, response);
 }
+
 /*
  * end connect account with google strategy
  */

--- a/middleware/passport.middleware.js
+++ b/middleware/passport.middleware.js
@@ -673,30 +673,18 @@ exports.linkFacebookAccount = async (req, profile, cb) => {
 /*
  * begin connect account with google strategy
  */
-exports.linkGoogleAccount = async (
-    req,
-    profile,
-    done
-) => {
-    let state = req.query.state.split('|')
-    let user_id = +state[0]
 
-    if (await User.exists({ idOnSn2: profile.id })) {
-        return done(null, profile, {
-            status: false,
-            message: 'account exist',
-        })
-    } else {
-        await User.updateOne(
-            { _id: user_id },
+exports.linkGoogleAccount = async (req, profile, done) => {
+    let state = req.query.state.split('|');
+    let user_id = +state[0];
+    let response = { status: false, message: 'account exist' };
 
-            { $set: { idOnSn2: profile.id, completed: true} }
-        )
-        return done(null, profile, {
-            status: true,
-            message: 'account_linked_with success',
-        })
+    if (!(await User.exists({ idOnSn2: profile.id }))) {
+        await User.updateOne({ _id: user_id }, { $set: { idOnSn2: profile.id, completed: true } });
+        response = { status: true, message: 'account_linked_with success' };
     }
+
+    return done(null, profile, response);
 }
 /*
  * end connect account with google strategy

--- a/middleware/passport.middleware.js
+++ b/middleware/passport.middleware.js
@@ -655,16 +655,18 @@ exports.telegramConnection = (req, res) => {
 /*
  * begin connect account with facebook strategy
  */
-exports.linkFacebookAccount = async (req, profile, cb) => {
+
+  exports.linkFacebookAccount = async (req, profile, cb) => {
     const user_id = +req.query.state.split('|')[0];
     const token_for_business = profile._json.token_for_business;
-    
-    if (await User.exists({ idOnSn: token_for_business })) {
-      return cb(null, profile, { status: false, message: 'account exist' });
+    let response =   { status: false, message: 'account exist' };
+    if (!(await User.exists({ idOnSn: token_for_business }))) {
+      await User.updateOne({ _id: user_id }, { $set: { idOnSn: token_for_business, completed: true } });
+      response = { status: true, message: 'account_linked_with success' };
     } 
   
-    await User.updateOne({ _id: user_id }, { $set: { idOnSn: token_for_business, completed: true } });
-    return cb(null, profile, { status: true, message: 'account_linked_with success' });
+    
+    return cb(null, profile, response);
   }
 /*
  * end connect account with facebook strategy

--- a/routes/login.routes.js
+++ b/routes/login.routes.js
@@ -68,9 +68,7 @@ const {
     signup_telegram_function,
     signin_telegram_function,
     verifyAuth,
-    sattConnect,
-    twitterAuthSignup,
-    twitterAuthSignin,
+    sattConnect
 } = require('../middleware/passport.middleware')
 const {
     persmissionsObjFb,
@@ -425,22 +423,6 @@ router.get('/signup/twitter', async (req, res, next) => {
     passport.authenticate('twitter')(req, res, next)
 })
 
-// passport.use(
-//     new TwitterStrategy(
-//         {
-//             consumerKey: process.env.TWITTER_CONSUMER_KEY,
-//             consumerSecret: process.env.TWITTER_CONSUMER_SECRET,
-//             callbackURL: process.env.BASEURL + 'auth/twitter/callback',
-//             profileFields: ['id', 'displayName', 'photos', 'email'],
-//             includeEmail: true,
-//         },
-//         async (req, accessToken, refreshToken, profile, cb) => {
-//             twitterAuthSignup(req, accessToken, refreshToken, profile, cb)
-//         }
-//     )
-// )
-
-// router.get('/auth/twitter', passport.authenticate('twitter'))
 
 router.get(
     '/twitter/callback',
@@ -506,44 +488,6 @@ router.get('/signin/twitter', async (req, res, next) => {
     passport.authenticate('twitter-signin')(req, res, next)
 })
 
-// passport.use(
-//     'twitter-signin',
-//     new TwitterStrategy(
-//         {
-//             consumerKey: process.env.TWITTER_CONSUMER_KEY,
-//             consumerSecret: process.env.TWITTER_CONSUMER_SECRET,
-//             callbackURL: process.env.BASEURL + '/auth/twitter/signin/callback',
-//             profileFields: ['id', 'displayName', 'photos', 'email'],
-//             includeEmail: true,
-//         },
-//         async function (req, accessToken, refreshToken, profile, cb) {
-//             twitterAuthSignin(req, accessToken, refreshToken, profile, cb)
-//         }
-//     )
-// )
-// router.get(
-//     '/twitter/signin/callback',
-//     passport.authenticate('twitter-signin'),
-//     async function (req, response) {
-//         try {
-//             var param = {
-//                 access_token: req.user.token,
-//                 expires_in: req.user.expires_in,
-//                 token_type: 'bearer',
-//                 scope: 'user',
-//             }
-//             response.redirect(
-//                 process.env.BASED_URL +
-//                     '/auth/login?token=' +
-//                     JSON.stringify(param)
-//             )
-//         } catch (e) {
-//             console.log(e)
-//         }
-//     },
-//     authSignInErrorHandler
-// )
-//end twitter
 
 /**
  * @swagger
@@ -566,7 +510,7 @@ passport.use(
     new FbStrategy(
         facebookCredentials('auth/callback/facebook/connection'),
         async function (req, accessToken, refreshToken, profile, cb) {
-            facebookAuthSignin(req, accessToken, refreshToken, profile, cb)
+            facebookAuthSignin(profile, cb)
         }
     )
 )

--- a/routes/profile.routes.js
+++ b/routes/profile.routes.js
@@ -90,6 +90,7 @@ const {
     connectTelegramAccount,
     linkGoogleAccount,
     linkFacebookAccount,
+    linkSocialAccount
 } = require('../middleware/passport.middleware')
 const {
     facebookCredentials,
@@ -1135,7 +1136,14 @@ passport.use(
     new FbStrategy(
         facebookCredentials('profile/callback/link/facebook'),
         async (req, accessToken, refreshToken, profile, cb) => {
-            linkFacebookAccount(req, profile, cb)
+            // linkFacebookAccount(req, profile, cb)
+            linkSocialAccount({
+                req,
+                profile,
+                done: cb,
+                token_field: 'idOnSn',
+                id_field: 'token_for_business'
+            })
         }
     )
 )
@@ -1183,7 +1191,12 @@ passport.use(
     new GoogleStrategy(
         googleCredentials('profile/callback/link/google'),
         async (req, accessToken, refreshToken, profile, done) => {
-            linkGoogleAccount(req,profile, done)
+            linkSocialAccount({
+                req,
+                profile,
+                done,
+                token_field: 'idOnSn2'
+            })
         }
     )
 )

--- a/routes/profile.routes.js
+++ b/routes/profile.routes.js
@@ -88,8 +88,6 @@ const {
     verifyAuth,
     telegram_connect_function,
     connectTelegramAccount,
-    linkGoogleAccount,
-    linkFacebookAccount,
     linkSocialAccount
 } = require('../middleware/passport.middleware')
 const {

--- a/routes/profile.routes.js
+++ b/routes/profile.routes.js
@@ -1135,7 +1135,7 @@ passport.use(
     new FbStrategy(
         facebookCredentials('profile/callback/link/facebook'),
         async (req, accessToken, refreshToken, profile, cb) => {
-            linkFacebookAccount(req, accessToken, refreshToken, profile, cb)
+            linkFacebookAccount(req, profile, cb)
         }
     )
 )
@@ -1183,7 +1183,7 @@ passport.use(
     new GoogleStrategy(
         googleCredentials('profile/callback/link/google'),
         async (req, accessToken, refreshToken, profile, done) => {
-            linkGoogleAccount(req, accessToken, refreshToken, profile, done)
+            linkGoogleAccount(req,profile, done)
         }
     )
 )


### PR DESCRIPTION
Reafactor isBlocked and handleSocialMediaSignin functions

The sattConnect function has been declared twice in the middleware import statement, leading to redundancy. The second declaration of sattConnect has been removed, making the code cleaner and avoiding confusion

Large blocks of code related to Twitter authentication using the TwitterStrategy have been commented out. These sections were responsible for handling signup and signin with Twitter. The commented-out sections include the declaration of a new TwitterStrategy with environment variables for the consumer key and secret, and callback URL, as well as the associated routes​

There are three changes related to Facebook and Google authentication:

The facebookAuthSignin function previously took five arguments: req, accessToken, refreshToken, profile, and cb. It has been refactored to take only two arguments: profile and cb​[1](https://github.com/SaTT-Wallet/Backend/pull/234/files)​.
The linkFacebookAccount function has been modified in a similar way, reducing the number of parameters from five to three: req, profile, and cb​ Similarly, the linkGoogleAccount function has been refactored to take three arguments instead of five: req, profile, and done​[1]