### PR TITLE
add the check for instagram reels

### DIFF
--- a/manager/oracles.js
+++ b/manager/oracles.js
@@ -644,11 +644,11 @@ const instagram = async (UserId, link) => {
             instagram_username: instagramUserName,
         })
         if (fbPage && fbPage.instagram_id) {
-            const instagram_id = fbPage.instagram_id
+            const instagramId = fbPage.instagram_id
             const fbProfile = await FbProfile.findOne({ UserId: UserId }).lean()
             if (fbProfile) {
                 const accessToken = await getNewAccessTokenInstagram(fbProfile.accessToken, oauth.facebook.fbGraphVersion);
-                const media = `https://graph.facebook.com/${oauth.facebook.fbGraphVersion}/${instagram_id}/media?fields=like_count,shortcode,media_url&limit=50&access_token=${accessToken}`
+                const media = `https://graph.facebook.com/${oauth.facebook.fbGraphVersion}/${instagramId}/media?fields=like_count,shortcode,media_url&limit=50&access_token=${accessToken}`
                 const resMedia = (await rp.get(media))
                 const data = resMedia.data.data
                 for (let i = 0; i < data.length; i++) {

--- a/manager/oracles.js
+++ b/manager/oracles.js
@@ -667,6 +667,7 @@ const instagram = async (UserId, link) => {
                             postPerformanceData.views = resMediaViews.data.data[0].values[0].value || 0
                         } catch (error) {
                             postPerformanceData.views = 0
+                            console.error('Error when fetching Instagram data', error)
                             return postPerformanceData
                         }
                         break


### PR DESCRIPTION
## PR Description:

Hello team,

This PR aims to resolve an issue we have been facing with our Instagram integration. Previously, when a user posted a video link (specifically, a Reels video), our API failed to fetch the view count for the media.

We have resolved this by introducing a check for the product_media_type in our Facebook Graph API calls. This check allows us to determine whether the link points to a Reels video or a regular post (picture or feed). Once the media type is identified, we can then accurately use the appropriate metrics - 'plays' for Reels videos, and 'impressions' for normal posts.

## Changes Made:

- Added a check for product_media_type in Facebook Graph API calls.
- Adjusted the metric used based on the type of media - using 'plays' for Reels videos and 'impressions' for other posts.


## Notes for Reviewers:

Please review the changes made, ensuring that the update appropriately checks for the media type and uses the correct metric. Make sure these changes do not introduce any unintended issues and that the application functions as expected when fetching view counts for different types of Instagram posts.

Your attention and contributions are highly appreciated. Please provide your valuable feedback and suggestions.

Best regards,
Louay HICHRI