### PR TITLE
Harvest threads link

### DIFF
--- a/controllers/campaign.controller.js
+++ b/controllers/campaign.controller.js
@@ -1832,7 +1832,6 @@ module.exports.linkStats = async (req, res) => {
             return responseHandler.makeResponseError(res, 204, 'link not found')
         }
     } catch (err) {
-        console.log({err})
         return responseHandler.makeResponseError(
             res,
             500,

--- a/controllers/campaign.controller.js
+++ b/controllers/campaign.controller.js
@@ -1781,20 +1781,27 @@ module.exports.linkStats = async (req, res) => {
                         abosNumber,
                         reachLimit
                     )
-                ratio.forEach((elem) => {
-                    if (elem.oracle === info.oracle) {
-                        let view = new Big(elem['view']).times(
-                            socialStats.views || '0'
-                        )
-                        let like = new Big(elem['like']).times(
-                            socialStats.likes || '0'
-                        )
-                        let share = new Big(elem['share']).times(
-                            socialStats.shares || '0'
-                        )
-                        totalToEarn = view.plus(like).plus(share).toFixed()
-                    }
-                })
+                    ratio.forEach((elem) => {
+                        if (elem.oracle === info.oracle) {
+                            if(elem.oracle === 'threads') {
+                                let like = new Big(elem['like']).times(
+                                    socialStats.likes || '0'
+                                )
+                                totalToEarn = like.toFixed()
+                            } else {
+                                let view = new Big(elem['view']).times(
+                                    socialStats.views || '0'
+                                )
+                                let like = new Big(elem['like']).times(
+                                    socialStats.likes || '0'
+                                )
+                                let share = new Big(elem['share']).times(
+                                    socialStats.shares || '0'
+                                )
+                                totalToEarn = view.plus(like).plus(share).toFixed()
+                            }
+                        }
+                    })
                 info.totalToEarn = new Big(totalToEarn).gte(
                     new Big(payedAmount)
                 )
@@ -1825,6 +1832,7 @@ module.exports.linkStats = async (req, res) => {
             return responseHandler.makeResponseError(res, 204, 'link not found')
         }
     } catch (err) {
+        console.log({err})
         return responseHandler.makeResponseError(
             res,
             500,


### PR DESCRIPTION
## PR Description:

Hello team,

This PR addresses an issue related to link harvesting for Threads Oracle. Users have encountered an error while attempting to harvest a link due to our Threads integration only utilizing "likes" and disabling "views" and "shares" at the moment.

To resolve this issue, we have implemented a check on the API to identify whether the oracle of a link is Threads. With this check in place, we can accurately calculate the totalToEarned, ensuring that link harvesting functions as expected for Threads Oracle.

## Changes Made:

- Added a check on the API to determine if the link's oracle is Threads.
- Calculated the totalToEarned accurately based on the check results.


## Notes for Reviewers:

Please review the changes made to ensure that the link harvesting issue for Threads Oracle is resolved effectively. Verify that users can now harvest links without encountering any errors and that the totalToEarned calculation is accurate for Threads Oracle links.

Your attention and contributions are highly appreciated. Feel free to provide any feedback or suggestions you may have.

Best regards,
Louay HICHRI