### PR TITLE
Sw 3634 updating statistics for a threads campaign

### DIFF
--- a/controllers/campaign.controller.js
+++ b/controllers/campaign.controller.js
@@ -2796,6 +2796,7 @@ module.exports.statLinkCampaign = async (req, res) => {
             youtube: initStat(),
             linkedin: initStat(),
             tiktok: initStat(),
+            threads: initStat(),
         };
 
         const links = await CampaignLink.find({ id_campaign });

--- a/web3/wallets.js
+++ b/web3/wallets.js
@@ -555,7 +555,7 @@ exports.getPrices = async () => {
                 url: process.env.CMC_URl,
                 params: {
                     start: '1',
-                    limit: '200',
+                    limit: '1200',
                     convert: 'USD',
                 },
                 headers: {


### PR DESCRIPTION
Dear team,

This PR addresses issues related to the Threads stats, specifically the total number of likes, views, and shares. The following changes have been made:

Fixing Threads Stats: We have resolved issues with the calculation of the total number of likes, views, and shares in Threads. The stats now accurately reflect the user engagement metrics, providing an up-to-date and reliable representation of the platform's performance.
By fixing the Threads stats, we ensure that users receive accurate and meaningful information about the engagement levels on the platform.

Reviewers, please verify that the Threads stats have been successfully fixed, and the total number of likes, views, and shares is calculated accurately. Ensure that the displayed metrics align with the actual user engagement data. Your feedback, suggestions, and alternative approaches to further improve the Threads stats are highly appreciated.

Thank you for your attention to detail and your dedication to delivering accurate and informative platform statistics.

Best regards,
Rania Morheg